### PR TITLE
Update FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,7 +2,7 @@
 
 ## How to run a processor against a different chain?
 
-You will need to have WebSocket endpoint to connect to the chain node and a Squid Archive. For a registry of Squid Archives, check this community-owned [Archive Registry](https://github.com/subsquid/archive-registry)
+You will need to have a WebSocket endpoint to connect to the chain node and a Squid Archive. For a registry of Squid Archives, check this community-owned [Archive Registry](https://github.com/subsquid/archive-registry)
 
 If you don't find a suitable Squid Archive in the registry, set up your own Squid archive. There are multiple examples in this [repo](https://github.com/subsquid/squid-archive-setup)
 


### PR DESCRIPTION
"You will need to have WebSocket endpoint to connect to the chain node and a Squid Archive."

Correction: "You will need to have a WebSocket endpoint to connect to the chain node and a Squid Archive."